### PR TITLE
fixed bug where raw data printed to browser

### DIFF
--- a/app/views/shelves/show.html.erb
+++ b/app/views/shelves/show.html.erb
@@ -12,7 +12,7 @@
 </p>
 <p>
 <h4>Books</h4>
-<%= @books.each do |book| %>
+<% @books.each do |book| %>
     <br>
     Book: <%= link_to book.title, book%>
 <%end%>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,7 +19,7 @@
 <% end %>
     <br>
     Shelves:
-    <%= @shelves.each do |shelf| %>
+    <% @shelves.each do |shelf| %>
         <br>
         Shelf:
         <%= link_to shelf.shelf_name, shelf %>


### PR DESCRIPTION
if you do

```
<%= @shelves.each do |shelf| %>
    ...
<% end %>
```

you'll end up printing raw data to the browser. In this case, you'd print the list of shelves. 

Instead, leave out the equal sign:

```
<% @shelves.each do |shelf| %>
    ...
<% end %>
```
